### PR TITLE
add ArdourOSC to directory.txt

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -4,6 +4,7 @@ AllGui=https://github.com/supercollider-quarks/AllGui
 AmbIEM=https://github.com/supercollider-quarks/AmbIEM
 APCmini=https://github.com/andresperezlopez/APCmini
 API=https://github.com/crucialfelix/API
+ArdourOSC=https://github.com/smoge/ArdourOSC
 arduino=https://github.com/supercollider-quarks/arduino
 ArduinoQuaternion=https://github.com/mtmccrea/ArduinoQuaternion
 astronomy=https://github.com/supercollider-quarks/astronomy


### PR DESCRIPTION
Bindings that allow SuperCollider code to control Ardour Audio Workstation, control of all the commands found in the GUI. 

https://github.com/smoge/ArdourOSC

https://ardour.org/