### PR TITLE
Add ddwLivecodeInstruments

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -49,6 +49,7 @@ ddwChucklib-livecode=https://github.com/jamshark70/ddwChucklib-livecode
 ddwCommon=https://github.com/jamshark70/ddwCommon
 ddwEQ=https://github.com/jamshark70/ddwEQ
 ddwGUIEnhancements=https://github.com/jamshark70/ddwGUIEnhancements
+ddwLivecodeInstruments=https://github.com/jamshark70/ddwLivecodeInstruments
 ddwMIDI=https://github.com/jamshark70/ddwMIDI
 ddwMixerChannel=https://github.com/jamshark70/ddwMixerChannel
 ddwPatterns=https://github.com/jamshark70/ddwPatterns


### PR DESCRIPTION
This is a set of prewritten instruments and processes for the ddwChucklib-livecode (cll) system, so  that users can start to play with cll notation without having to build processes for themselves.