### PR TITLE
Add ATK Quark.

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -8,6 +8,7 @@ ArdourOSC=https://github.com/smoge/ArdourOSC
 arduino=https://github.com/supercollider-quarks/arduino
 ArduinoQuaternion=https://github.com/mtmccrea/ArduinoQuaternion
 astronomy=https://github.com/supercollider-quarks/astronomy
+ATK=https://github.com/ambisonictoolkit/atk-sc3@tags/v4.0.0
 AudacityLabels=https://github.com/musikinformatik/AudacityLabels
 audiodomeSoundblox=https://github.com/supercollider-quarks/audiodomeSoundblox
 AudioMulchClock=https://github.com/supercollider-quarks/AudioMulchClock


### PR DESCRIPTION
Add "Quarkified" ATK.

- Class and Help files for the ATK are now distributed via https://github.com/ambisonictoolkit/atk-sc3.
- Plugins remain in sc3-plugins.