### PR TITLE
remove CVCenter from directory.txt

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -40,7 +40,6 @@ cruciallib=https://github.com/supercollider-quarks/cruciallib@tags/4.1.4
 crucialviews=https://github.com/crucialfelix/crucialviews
 Ctk=https://github.com/supercollider-quarks/Ctk
 CuePlayer=https://github.com/dathinaios/cueplayer
-CVCenter=https://github.com/nuss/CVCenter
 cxaudio=https://github.com/crucialfelix/cxaudio
 cxpatterns=https://github.com/crucialfelix/cxpatterns
 DataNetwork=https://github.com/supercollider-quarks/DataNetwork


### PR DESCRIPTION
In its current configuartion CVCenter will not install properly as a
quark. It depends on a tweaked version of the Conductor library, its
helpfiles need to be updated and in general I would like to rewrite it
from scratch. It should, however, work if cloned including Conductor as
a submodule from https://github.com/nuss/cvcenter.

Signed-off-by: Stefan Nussbaumer <st9fan@gmail.com>