### PR TITLE
addition of the OSSIA quark

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -162,6 +162,7 @@ OpenObject=https://github.com/supercollider-quarks/OpenObject
 orb=https://github.com/supercollider-quarks/orb
 OSCClocks=https://github.com/supercollider-quarks/OSCClocks
 OscGroupClient=https://github.com/supercollider-quarks/OscGroupClient
+OSSIA=https://github.com/OSSIA/ossia-sclang
 PaneView=https://github.com/vividsnow/sc-paneview
 PitchCircle=https://github.com/supercollider-quarks/PitchCircle
 PitchShiftPA=https://github.com/dyfer/PitchShiftPA


### PR DESCRIPTION
This is a first draft, before moving on to OSCQuerry support.
It will require Pierre Cochard's wsclang build
https://github.com/pchdev/wsclang 
And will provide convenience classes and examples showing the interest of the protocol,
especially to communicate with the interactive sequencer ossia-score
https://github.com/OSSIA/score

for now, the quark only supports "regular" OSC