### PR TITLE
add EuroCollider

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -84,6 +84,7 @@ Ease=https://github.com/redFrik/Ease
 egSC=https://github.com/lnihlen/egSC
 EnvScaleView=https://github.com/michaeldzjap/EnvScaleView
 Esp=https://github.com/d0kt0r0/Esp.sc
+EuroCollider=https://github.com/capital-G/EuroCollider
 EventArray=https://github.com/musikinformatik/EventArray
 ExtraWindows=https://github.com/khoin/ExtraWindows@tags/0.1.1
 FancySlider=https://github.com/jmuxfeldt/FancySlider


### PR DESCRIPTION
Add [EuroCollider](https://github.com/capital-G/EuroCollider), a library which allows to connect with EuroRack modules.