### PR TITLE
remove Scintillator, a deprecated Quark

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -236,7 +236,6 @@ ScampUtils=https://github.com/MarcTheSpark/SCScampUtils
 SCAnimation=https://github.com/supercollider-quarks/SCAnimation
 scgraph=https://github.com/supercollider-quarks/scgraph
 sc-grids=https://github.com/capital-G/sc-grids
-Scintillator=https://github.com/ScintillatorSynth/Scintillator
 SCLemurLib=https://github.com/marinusklaassen/SCLemurLib@tags/v0.1.0-beta.1
 SCLOrkSynths=https://github.com/SCLOrkHub/SCLOrkSynths
 SCLOrkTools=https://github.com/SCLOrkHub/SCLOrkTools


### PR DESCRIPTION
Scintillator is deprecated, remove it from the Quarks list.