### PR TITLE
Remove unit testing quark

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -294,7 +294,6 @@ turtle=https://github.com/supercollider-quarks/turtle
 UGenPatterns=https://github.com/redFrik/UGenPatterns
 UGenStructure=https://github.com/supercollider-quarks/UGenStructure
 Unit-Lib=https://github.com/GameOfLife/Unit-Lib
-UnitTesting=https://github.com/supercollider-quarks/UnitTesting
 Utopia=https://github.com/muellmusik/Utopia
 Vapor=https://github.com/supercollider-quarks/Vapor
 VectorSpace=https://github.com/supercollider-quarks/VectorSpace


### PR DESCRIPTION
The `UnitTesting` quark has been part of the standard library since 3.9.0 released in 2019.
Installing this quark since would yield a compilation error, so it is probably best to remove it from the directory in order to not confuse people.

Also have a PR on the repo itself about it -> https://github.com/supercollider-quarks/UnitTesting/pull/5
