### PR TITLE
Add warning against bundling external Extensions inside Quarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ These are folders that contain many quarks. Those will then be shown on the GUI 
 Quarks.addFolder("~/supercollider/quarks");
 ```
 
+> [!WARNING]
+> Do not include plugins, extensions, or classes distributed by others directly inside your Quark folder. SuperCollider loads Extensions globally, so placing an external Extension inside a Quark can cause duplicate class errors for users who have already installed that Extension separately, according to that extensionʼs installation instructions.
+>
+> Example:
+> ```supercollider
+> ERROR: duplicate Class found: 'SomeClassName'
+> ~/Library/Application Support/SuperCollider/Extensions/SomeExtension/classes/...
+> ~/Library/Application Support/SuperCollider/downloaded-quarks/YourQuark/classes/...
+> ```
+> 
+> If your Quark depends on an external Extension, declare it as a dependency in your `README` file or in the Quark metadata, rather than bundling the Extension itself.
 
 ---
 


### PR DESCRIPTION
Recently, I encountered a Quark that included an external Extension both as a
declared dependency and also bundled the Extension inside its own directory:
https://scsynth.org/t/performative-a-toolkit-for-creating-performance-instruments-and-designing-parameters-in-supercollider/13461/11?u=prko

This caused unnecessary errors, forcing users to remove the Extension from the
SC-IDE Preferences path and manually delete the folder in Finder or any equivalent
file manager.

This PR adds a warning to address this problematic practice among some Quark authors.

See: https://github.com/supercollider/supercollider/pull/7654